### PR TITLE
Fix process group form override

### DIFF
--- a/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
@@ -1,4 +1,5 @@
 <!-- insert_bottom "div#panel-visibility" -->
-<% if controller.action_name == "edit" %>
-  <%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
-<% end %>
+<% participatory_space = params[:id].nil? ? nil : participatory_process_group %>
+
+<%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_space %>
+

--- a/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
@@ -1,3 +1,4 @@
 <!-- insert_bottom "div#panel-visibility" -->
-
-<%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
+<% if controller.action_name == "edit" %>
+  <%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
+<% end %>


### PR DESCRIPTION
#### :tophat: Description
The aim of this PR is to add a condition on the override of process group form, so that the override only applies on edit view, and not in new where it causes an error (cf screenshot).

#### Testing

1. As an admin, go to processes > process groups
2. Click on 'New process group'
3. See that you can access the new view without error

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=144469129&issue=OpenSourcePolitics%7Cintern-tasks%7C286

#### :camera: Screenshots
<img width="1196" height="649" alt="Capture d’écran 2025-12-17 à 13 47 27" src="https://github.com/user-attachments/assets/3cddb1fe-6140-4aa6-b0dc-4124e080f461" />

